### PR TITLE
use react-shallow-compare lib

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "dependencies": {
     "classnames": "^2.2.3",
+    "react-addons-shallow-compare": "^15.6.2",
     "lodash.debounce": "^4.0.6"
   },
   "devDependencies": {

--- a/src/input.jsx
+++ b/src/input.jsx
@@ -3,6 +3,7 @@ import classnames from 'classnames';
 
 import filterInputAttributes from './filter-input-attributes';
 import PropTypes from 'prop-types';
+import shallowCompare from 'react-addons-shallow-compare';
 
 /**
  * The input field

--- a/src/suggest-item.jsx
+++ b/src/suggest-item.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import classnames from 'classnames';
 import PropTypes from 'prop-types';
+import shallowCompare from 'react-addons-shallow-compare';
 
 /**
  * A single Geolookup item in the list

--- a/src/suggest-list.jsx
+++ b/src/suggest-list.jsx
@@ -2,6 +2,7 @@ import React from 'react'; // eslint-disable-line no-unused-vars
 import classnames from 'classnames';
 import SuggestItem from './suggest-item';
 import PropTypes from 'prop-types';
+import shallowCompare from 'react-addons-shallow-compare';
 
 /**
  * The list with suggestions. Either from an API or provided as fixture


### PR DESCRIPTION
Hi folks,

We've included the react-addons-shallow-compare lib in the package.json, which is now necessary as it's been deprecated in React itself. This mirrors what's been done in the `react-geosuggest` in this commit: https://github.com/ubilabs/react-geosuggest/commit/3dcf20980f8126f65d07371ac8770f04ebbe4065

This closes #5 

Ed